### PR TITLE
Governance: General governance and Terminology governance

### DIFF
--- a/docs/assets/documents/GeneralGovernanceFHIRStandards.md
+++ b/docs/assets/documents/GeneralGovernanceFHIRStandards.md
@@ -1,0 +1,49 @@
+[Return](../../index.md)
+
+# TouchStone getting started
+<hr>
+
+**Table of contents**
+* [1 How to register](#1-how-to-register)
+* [2 How to run a Touchstone test script based on use cases](#2-how-to-run-a-touchstone-test-script-based-on-use-cases)
+
+<!-- [3 Touchstone .NET client Demo](#3-touchstone-net-client-demo)
+ [4 Java FHIR client setup](#4-java-fhir-client-setup) -->
+
+This page presents a short introduction to the test tool called "TouchStone", which is used to perform tests of MedCom FHIR standards. The introduction is based on Touchstone's own guides and is divided into two sections: the first section will contain information about how to register on "TouchStone" wherease, the second section will contain information about how to run a test script. 
+
+
+
+## 1 How to register
+
+1. To register, please go to <a href="https://touchstone.aegis.net/touchstone/login" target="_blank">Touchstone</a> <a href="https://touchstone.aegis.net/touchstone/userguide/html/registration-and-login/register.html" target= "_blank">and follow steps.</a>
+
+2. To execute test you need to be a member of an organization. If your organization allready eksist assign to it.If you are the first user from your organization, <a href="https://touchstone.aegis.net/touchstone/userguide/html/registration-and-login/membership.html#new-organization" target="_blank"> pleas create your organization by follow the following steps.</a> 
+
+3. You need to be a part of the MedCom OrgGroup, to be able to access the test scripts. To become a member, pleas send a request to <a href="mailto:fhir@medcom.dk">fhir@medcom.dk</a>.
+
+> Note: You need to wait until we accept your request before you can run the test. As soon as we accept your request, you will be notified via email. Please check your spam folder in case the emails get directed there.
+<br>
+
+## 2 How to run a Touchstone test script based on use cases
+
+1. To be able to run TouchStone test scripts you need to create a test system. Sign into your TouchStone account click on the "Test system" button in the top menu and choose "New test". Follow the two first steps in the following  <a href="https://touchstone.aegis.net/touchstone/userguide/html/test-systems/creating.html" target="_blank">guide</a>. 
+ >Note When creating a "Test system ", you need to choose whether the system that you want to test schould acts as 'origin' or 'destination'.
+
+2. Create then "Test setup" by  <a href="https://touchstone.aegis.net/touchstone/userguide/html/executing-tests/test-setup.html" target="_blank"> the following steps</a>. 
+<!-- 3. Ensure that you have a program that can build and use API to test   -->
+3. To execute the test choose the testscript under "Test definition" and <a href="https://touchstone.aegis.net/touchstone/userguide/html/executing-tests/test-execs.html" target="_blank">follow the steps</a>.  
+4. To read the test results,do the following <a href="https://touchstone.aegis.net/touchstone/userguide/html/executing-tests/test-exec-results.html" target="_blank">steps</a>.
+
+
+
+<!-- ## 3 Touchstone .NET client Demo
+[Demo of a .NET client](https://github.com/medcomdk/touchstone-client-demo-dotnet) calling the MedCom Touchstone test Suite 
+
+
+## 4 Java FHIR client setup
+[http://svn.medcom.dk/svn/drafts/TestProcedurer/Touchstone/MedcomTouchstoneTest/java%20FHIR%20client.pptx](http://svn.medcom.dk/svn/drafts/TestProcedurer/Touchstone/MedcomTouchstoneTest/java%20FHIR%20client.pptx) -->
+
+<!-- ## 5 Release Notes
+
+[The latest changes of this page can be found here.](ReleaseNotesTouchStoneGettingStarted.md) -->

--- a/docs/assets/documents/GeneralGovernanceFHIRStandards.md
+++ b/docs/assets/documents/GeneralGovernanceFHIRStandards.md
@@ -6,8 +6,8 @@
 * [1 Introduction to General Governance for MedCom FHIR Standards](#1-introduction-to-general-governance-for-medcom-fhir-standards)
 * [2 Special terms used in the general Governance for MedCom FHIR Standards](#2-special-terms-used-in-the-general-governance-for-medcom-fhir-standards)
 * [3 MedCom FHIR standards](#3-medcom-fhir-standards)
-* [4 4 Governance for concrete MedCom FHIR Standards](#4-governance-for-concrete-medcom-fhir-standards)
-  + [4.1 Versioning of MedCom FHIR Standards](#41-versioning-of-medcom-fhir-standards)
+* [4 Governance for concrete MedCom FHIR Standards](#4-governance-for-concrete-medcom-fhir-standards)
+  + [4.1 Versions of MedCom FHIR Standards](#41-versions-of-medcom-fhir-standards)
 
 <br>
 
@@ -47,12 +47,9 @@ An implementer of a MedCom FHIR  Standard **SHALL** be compliant with all parts 
 
 ## 4 Governance for concrete MedCom FHIR Standards
 
-Each MedCom FHIR standard will potentially add some specific Governance Rules to the mix of overall Governance Rules. These are handled on a separate page, to which the specific standard also will link to.
+Each MedCom FHIR standard will potentially add some specific Governance Rules to the mix of overall Governance Rules. These are handled separately, to which the specific standard will link to.
 
-[Click here to go to Governance for concrete MedCom FHIR Message Standards.](/assets/documents/090_Governance-for-concrete-standards.md)
-<!-- RCH: link i stedet til landingpage direkte -->
-
-### 4.1 Versioning of MedCom FHIR Standards
+### 4.1 Versions of MedCom FHIR Standards
 Vendors should be prepared to handle multiple versions of a MedCom FHIR standard.
 The version of the standard is not explicitly stated in a message. 
 

--- a/docs/assets/documents/GeneralGovernanceFHIRStandards.md
+++ b/docs/assets/documents/GeneralGovernanceFHIRStandards.md
@@ -51,6 +51,8 @@ Each MedCom FHIR standard will potentially add some specific Governance Rules to
 
 ### 4.1 Versions of MedCom FHIR Standards
 Vendors should be prepared to handle multiple versions of a MedCom FHIR standard.
-The version of the standard is not explicitly stated in a message. 
+The version of the standard is not explicitly stated in a bundle.
 
-When receiving a MedCom FHIR Bundle, it should be validated against the rules and contraints defined in the associtated Implementaiotn guide of the same version. With breaking changes, MedCom will provide specific guidelines for the scenario.
+MedCom is, as of 2025, starting to introduce references in the MessageHeader to MessageDefinitions via the `definition` element. This means that future releases containing MessageHeaders will have an associated MessageDefinition linked. You can find the Implementation Guide for MessageDefinitions [here](https://medcomfhir.dk/ig/messagedefinitions/).
+
+When receiving a MedCom FHIR Bundle, it should be validated against the rules and contraints defined in the associtated Implementation guide of the same version. With breaking changes, MedCom will provide specific guidelines for the scenario.

--- a/docs/assets/documents/GeneralGovernanceFHIRStandards.md
+++ b/docs/assets/documents/GeneralGovernanceFHIRStandards.md
@@ -53,6 +53,4 @@ Each MedCom FHIR standard will potentially add some specific Governance Rules to
 Vendors should be prepared to handle multiple versions of a MedCom FHIR standard.
 The version of the standard is not explicitly stated in a bundle.
 
-MedCom is, as of 2025, starting to introduce references in the MessageHeader to MessageDefinitions via the `definition` element. This means that future releases containing MessageHeaders will have an associated MessageDefinition linked. You can find the Implementation Guide for MessageDefinitions [here](https://medcomfhir.dk/ig/messagedefinitions/). MessageDefinitions contains the the standard's version.
-
 When receiving a MedCom FHIR Bundle, it should be validated against the rules and contraints defined in the associtated Implementation guide of the same version. With breaking changes, MedCom will provide specific guidelines for the scenario.

--- a/docs/assets/documents/GeneralGovernanceFHIRStandards.md
+++ b/docs/assets/documents/GeneralGovernanceFHIRStandards.md
@@ -53,6 +53,6 @@ Each MedCom FHIR standard will potentially add some specific Governance Rules to
 Vendors should be prepared to handle multiple versions of a MedCom FHIR standard.
 The version of the standard is not explicitly stated in a bundle.
 
-MedCom is, as of 2025, starting to introduce references in the MessageHeader to MessageDefinitions via the `definition` element. This means that future releases containing MessageHeaders will have an associated MessageDefinition linked. You can find the Implementation Guide for MessageDefinitions [here](https://medcomfhir.dk/ig/messagedefinitions/).
+MedCom is, as of 2025, starting to introduce references in the MessageHeader to MessageDefinitions via the `definition` element. This means that future releases containing MessageHeaders will have an associated MessageDefinition linked. You can find the Implementation Guide for MessageDefinitions [here](https://medcomfhir.dk/ig/messagedefinitions/). MessageDefinitions contains the the standard's version.
 
 When receiving a MedCom FHIR Bundle, it should be validated against the rules and contraints defined in the associtated Implementation guide of the same version. With breaking changes, MedCom will provide specific guidelines for the scenario.

--- a/docs/assets/documents/GeneralGovernanceFHIRStandards.md
+++ b/docs/assets/documents/GeneralGovernanceFHIRStandards.md
@@ -1,49 +1,59 @@
 [Return](../../index.md)
 
-# TouchStone getting started
-<hr>
+# General Governance for MedCom FHIR Standards
 
 **Table of contents**
-* [1 How to register](#1-how-to-register)
-* [2 How to run a Touchstone test script based on use cases](#2-how-to-run-a-touchstone-test-script-based-on-use-cases)
+* [1 Introduction to General Governance for MedCom FHIR Standards](#1-introduction-to-general-governance-for-medcom-fhir-standards)
+* [2 Special terms used in the general Governance for MedCom FHIR Standards](#2-special-terms-used-in-the-general-governance-for-medcom-fhir-standards)
+* [3 MedCom FHIR standards](#3-medcom-fhir-standards)
+* [4 4 Governance for concrete MedCom FHIR Standards](#4-governance-for-concrete-medcom-fhir-standards)
+  + [4.1 Versioning of MedCom FHIR Standards](#41-versioning-of-medcom-fhir-standards)
 
-<!-- [3 Touchstone .NET client Demo](#3-touchstone-net-client-demo)
- [4 Java FHIR client setup](#4-java-fhir-client-setup) -->
-
-This page presents a short introduction to the test tool called "TouchStone", which is used to perform tests of MedCom FHIR standards. The introduction is based on Touchstone's own guides and is divided into two sections: the first section will contain information about how to register on "TouchStone" wherease, the second section will contain information about how to run a test script. 
-
-
-
-## 1 How to register
-
-1. To register, please go to <a href="https://touchstone.aegis.net/touchstone/login" target="_blank">Touchstone</a> <a href="https://touchstone.aegis.net/touchstone/userguide/html/registration-and-login/register.html" target= "_blank">and follow steps.</a>
-
-2. To execute test you need to be a member of an organization. If your organization allready eksist assign to it.If you are the first user from your organization, <a href="https://touchstone.aegis.net/touchstone/userguide/html/registration-and-login/membership.html#new-organization" target="_blank"> pleas create your organization by follow the following steps.</a> 
-
-3. You need to be a part of the MedCom OrgGroup, to be able to access the test scripts. To become a member, pleas send a request to <a href="mailto:fhir@medcom.dk">fhir@medcom.dk</a>.
-
-> Note: You need to wait until we accept your request before you can run the test. As soon as we accept your request, you will be notified via email. Please check your spam folder in case the emails get directed there.
 <br>
 
-## 2 How to run a Touchstone test script based on use cases
+## 1 Introduction to General Governance for MedCom FHIR Standards
 
-1. To be able to run TouchStone test scripts you need to create a test system. Sign into your TouchStone account click on the "Test system" button in the top menu and choose "New test". Follow the two first steps in the following  <a href="https://touchstone.aegis.net/touchstone/userguide/html/test-systems/creating.html" target="_blank">guide</a>. 
- >Note When creating a "Test system ", you need to choose whether the system that you want to test schould acts as 'origin' or 'destination'.
+On this page, you can find information about how MedCom has profiled FHIR standards to work in a Danish context.
+Governance for MedCom HL7 FHIR  describes the basic ruleset of how MedCom standards must be implemented in the Danish Healthcare System.
 
-2. Create then "Test setup" by  <a href="https://touchstone.aegis.net/touchstone/userguide/html/executing-tests/test-setup.html" target="_blank"> the following steps</a>. 
-<!-- 3. Ensure that you have a program that can build and use API to test   -->
-3. To execute the test choose the testscript under "Test definition" and <a href="https://touchstone.aegis.net/touchstone/userguide/html/executing-tests/test-execs.html" target="_blank">follow the steps</a>.  
-4. To read the test results,do the following <a href="https://touchstone.aegis.net/touchstone/userguide/html/executing-tests/test-exec-results.html" target="_blank">steps</a>.
+<br>
 
+These general MedCom FHIR Governance rules are intended to clarify the use of MedCom’s FHIR standards for the health and social area.
 
-
-<!-- ## 3 Touchstone .NET client Demo
-[Demo of a .NET client](https://github.com/medcomdk/touchstone-client-demo-dotnet) calling the MedCom Touchstone test Suite 
+It is the intention that the general MedCom FHIR Governance rules together with MedCom’s individual FHIR standards form the full and sufficient basis for implementing MedCom’s healthcare FHIR standards. Thus, the governance rules must be able to function as “a chief judge”, where there is doubt about the practical application of MedCom’s FHIR standards.
 
 
-## 4 Java FHIR client setup
-[http://svn.medcom.dk/svn/drafts/TestProcedurer/Touchstone/MedcomTouchstoneTest/java%20FHIR%20client.pptx](http://svn.medcom.dk/svn/drafts/TestProcedurer/Touchstone/MedcomTouchstoneTest/java%20FHIR%20client.pptx) -->
+### 2 Special terms used in the general Governance for MedCom FHIR Standards
 
-<!-- ## 5 Release Notes
+MedCom adopts the normative words defined in IETF Best Current Practice 14: Key words for use in RFCs to Indicate Requirement Levels (BCP-14) (currently RFC 2119 and RFC 8174), certain words indicate whether a specific content of the Technical Framework is normative: either required (e.g., “must”, “required”, “shall”) or optional (e.g., “may”, “recommended”). Informative content does not contain these key words.
 
-[The latest changes of this page can be found here.](ReleaseNotesTouchStoneGettingStarted.md) -->
+<a href="https://www.rfc-editor.org/info/rfc2119" target="_blank">RFC 2119</a> specifies common key words that may be used in protocol specifications, where <a href="https://www.rfc-editor.org/info/rfc8174" target="_blank">RFC 8174</a> aims to reduce the ambiguity by clarifying that only UPPERCASE usage of the key words have the defined special meanings.
+
+This specification uses the conformance verbs SHALL, SHOULD, and MAY as defined in RFC 2119. Unlike RFC 2119, however, this specification allows that different applications might not be able to interoperate because of how they use optional features. In particular:
+
+* **SHALL**: (or “REQUIRED” or “MUST”) an absolute requirement for all implementations
+* **SHALL NOT**: (or "MUST NOT") an absolute prohibition against inclusion for all implementations
+* **SHOULD/SHOULD NOT**: (or “RECOMMENDED”/“NOT RECOMMENDED”) A best practice or recommendation to be considered by implementers within the context of their particular implementation; there may be valid reasons to ignore an item, but the full implications must be understood and carefully weighed before choosing a different course
+* **MAY**: (or "OPTIONAL") This is truly optional language for an implementation; can be included or omitted as the implementer decides with no implications
+
+<br>
+
+This convention is in compliance with HL7 FHIR use of the terms, which is descibed by <a href="http://www.hl7.org/fhir/conformance-rules.html#conflang" target="_blank">HL7 FHIR under conformance language</a>.
+
+
+## 3 MedCom FHIR standards
+
+An implementer of a MedCom FHIR  Standard **SHALL** be compliant with all parts of the documentation (both the standard documentation and the relevant governance).
+
+## 4 Governance for concrete MedCom FHIR Standards
+
+Each MedCom FHIR standard will potentially add some specific Governance Rules to the mix of overall Governance Rules. These are handled on a separate page, to which the specific standard also will link to.
+
+[Click here to go to Governance for concrete MedCom FHIR Message Standards.](/assets/documents/090_Governance-for-concrete-standards.md)
+<!-- RCH: link i stedet til landingpage direkte -->
+
+### 4.1 Versioning of MedCom FHIR Standards
+Vendors should be prepared to handle multiple versions of a MedCom FHIR standard.
+The version of the standard is not explicitly stated in a message. 
+
+When receiving a MedCom FHIR Bundle, it should be validated against the rules and contraints defined in the associtated Implementaiotn guide of the same version. With breaking changes, MedCom will provide specific guidelines for the scenario.

--- a/docs/assets/documents/GovernanceTerminology.md
+++ b/docs/assets/documents/GovernanceTerminology.md
@@ -64,7 +64,7 @@ Each component of the version number signals the type and impact of a change. An
 Examples:
 
 * A minor change in a ValueSet will result in a minor version change in the standards that incorporate it. 
-* MedCom releases a new major version of multiple terminology artefacts not used in MedCom standard A. Standard A’s version is then not affected on any level.
+* MedCom releases a new major version of multiple terminology artefacts not used in MedCom Standard A. Standard A’s version is then not affected on any level.
 
 #### 2.1.1 Major version
 
@@ -93,7 +93,7 @@ The patch version (X.Y.Z) is incremented for small changes that are backward com
 Examples include: 
 
 * Corrections to display names or definitions that do not affect semantic meaning. 
-* Making small technical or editorial updates or fixing bugs that do not affect system behaviour or require changes by users. 
+* Making small technical or editorial updates or fixing bugs that do not affect system behaviour or require changes by users.
 
 ### 2.2 Versioning of MedCom Terminology IG
 
@@ -107,9 +107,9 @@ Changes are documented in the [Directory of published versions](https://medcomfh
 
 Examples: 
 
-* A new version of MedCom Terminology has been released as a major version which includes changes to artefacts (e.g. ValueSets and CodeSystems) not used in MedCom standard A. Standard A’s version is not affected at any level. 
-* A new version of MedCom Terminology has been released. ValueSet A’s version is changed at the minor level and the MedCom Terminology is changed at the patch level. Standard A, which incorporates ValueSet A, is updated on the major level. 
-* A new version of MedCom Terminology has been released, and it includes changes to multiple artefacts (e.g. ValueSets and CodeSystems) used in MedCom standard A. The IG of MedCom standard A will be updated to match the highest version change level (major > minor > patch) among the individual terminology artefacts it incorporates and not the version of the MedCom Terminology IG itself. 
+* A new version of MedCom Terminology has been released as a major version which includes changes to artefacts (e.g. ValueSets and CodeSystems) not used in MedCom Standard A. Standard A’s version is not affected at any level.
+* A new version of MedCom Terminology has been released. ValueSet B’s version is changed at the minor level and the MedCom Terminology is changed at the patch level. Standard B, which incorporates ValueSet B, is updated on the major level. 
+* A new version of MedCom Terminology has been released, and it includes changes to multiple artefacts (e.g. ValueSets and CodeSystems) used in MedCom Standard C. The IG of MedCom Standard C will be updated to match the highest version change level (major > minor > patch) among the individual terminology artefacts it incorporates and not the version of the MedCom Terminology IG itself.
 
 #### 2.2.1 Major version
 

--- a/docs/assets/documents/GovernanceTerminology.md
+++ b/docs/assets/documents/GovernanceTerminology.md
@@ -73,7 +73,8 @@ The major version (X.0.0) is incremented when changes are introduced that may br
 Examples include:
 
 * Structural changes to existing terminology artefacts. 
-* Changing or deprecating existing codes. 
+* Changing or deprecating existing codes.
+* Corrections to display names that impacts functionality in systems using the terminology.
 * Embedding a group from one terminology artefact into another terminology artefact. 
 * Adding, deprecating or changing a code in a way that impacts functionality in systems using the terminology.
 
@@ -83,7 +84,8 @@ The minor version (X.Y.0) is incremented when new content is added in a way that
 
 Examples include: 
 
-* Addition of one or more new codes to existing terminology artefacts (e.g. a new category). 
+* Addition of one or more new codes to existing terminology artefacts (e.g. a new category).
+* Corrections to display names that do not affect semantic meaning.
 * Changes that do not affect functionality but still require updated documentation or user guidance – e.g. clarifying a code definition or providing new usage instructions. 
 
 #### 2.1.3 Patch version
@@ -92,7 +94,7 @@ The patch version (X.Y.Z) is incremented for small changes that are backward com
 
 Examples include: 
 
-* Corrections to display names or definitions that do not affect semantic meaning. 
+* Corrections to descriptions that do not affect semantic meaning. 
 * Making small technical or editorial updates or fixing bugs that do not affect system behaviour or require changes by users.
 
 ### 2.2 Versioning of MedCom Terminology IG

--- a/docs/assets/documents/GovernanceTerminology.md
+++ b/docs/assets/documents/GovernanceTerminology.md
@@ -129,7 +129,7 @@ Examples include:
 
 * Addition of entirely new CodeSystems or ValueSets. 
 * Addition of a new group of codes (e.g. a new domain or category within an existing CodeSystem). 
-* Adding, deprecating or changing a code in a way that impacts functionality in systems using the terminology. 
+* Adding, deprecating or changing a code or display name in a way that impacts functionality in systems using the terminology. 
 
 Changes that do not affect terminology functionality but still require updated documentation or user guidance. 
 
@@ -140,7 +140,7 @@ The patch version (X.Y.Z) is incremented for small changes that are backward com
 Examples include: 
 
 * Addition of new individual codes to an existing artefact that do not affect system functionality. 
-* Corrections to display names or definitions that do not affect semantic meaning. 
+* Corrections to descriptions that do not affect semantic meaning. 
 * Small technical or editorial updates (like contact info or version notes) that do not affect system behavior or require changes by users. 
 
 ## 3 Governance for Terminology artefact dates

--- a/docs/assets/documents/GovernanceTerminology.md
+++ b/docs/assets/documents/GovernanceTerminology.md
@@ -1,0 +1,134 @@
+[Return](../../index.md)
+
+# Governance for Medcom FHIR Terminology
+
+**Table of contents**
+* [1 Introduction to Governance for MedCom FHIR Terminology](#1-introduction-to-governance-for-medcom-fhir-terminology)
+* [2 Versioning of individual artefacts in the MedCom Terminology IG](#2-versioning-of-individual-artefacts-in-the-medcom-terminology-ig)
+  + [2.1 Major version](#21-major-version)
+  + [2.2 Minor version](#22-minor-version)
+  + [2.3 Patch version](#23-patch-version)
+* [3 Versioning of MedCom Terminology IG](#3-versioning-of-medcom-terminology-ig)
+  + [3.1 Major version](#31-major-version)
+  + [3.2 Minor version](#32-minor-version)
+  + [3.3 Patch version](#33-patch-version)
+* [4 Governance for Terminology artefact dates](#4-governance-for-terminology-artefact-dates)
+
+<br>
+
+## 1 Introduction to Governance for MedCom FHIR Terminology
+
+Governance for MedCom FHIR Terminology covers version management and dates Codesystems, Valuesets and ConceptMaps, which are published through the MedCom FHIR Terminology IG.
+
+<br>
+
+MedCom defines a separation between versioning of the overall MedCom Terminology Implementation Guide (IG) and the individual terminology artefacts, such as CodeSystems, ValueSets, and ConceptMaps. While the Terminology IG is versioned as a whole, each terminology artefact is versioned independently to ensure precise tracking of changes and stable references across MedCom standards.
+
+## 2 Versioning of individual artefacts in the MedCom Terminology IG
+
+MedCom applies a versioning model to manage updates to individual MedCom FHIR Terminology artefacts (CodeSystems, ValueSets, ConceptMaps), using the format Major.Minor.Patch. 
+
+Each component of the version number signals the type and impact of a change. Any MedCom standards affected by changes of individual terminology artefacts in the MedCom Terminology IG will reflect the same version change level as the artefact it incorporates that has the highest level of change (major > minor > patch). MedCom will communicate changes at the major and minor version levels to affected vendors. Vendors must be able to handle patch level changes without being notified by MedCom.
+
+<br>
+
+Examples:
+
+* A minor change in a ValueSet will result in a minor version change in the standards that incorporate it. 
+* MedCom releases a new major version of multiple terminology artefacts not used in MedCom standard A. Standard A’s version is then not affected on any level.
+
+### 2.1 Major version
+
+The major version (X.0.0) is incremented when changes are introduced that may break backward compatibility or significantly alter the structure or meaning of the individual terminology artefact. 
+
+Examples include:
+
+* Structural changes to existing terminology artefacts. 
+* Changing or deprecating existing codes. 
+* Embedding a group from one terminology artefact into another terminology artefact. 
+* Adding, deprecating or changing a code in a way that impacts functionality in systems using the terminology.
+
+### 2.2 Minor version
+
+The minor version (X.Y.0) is incremented when new content is added in a way that is fully backward compatible and does not alter the structure or semantics of existing terminology artefacts. 
+
+Examples include: 
+
+* Addition of one or more new codes to existing terminology artefacts (e.g. a new category). 
+* Changes that do not affect functionality but still require updated documentation or user guidance – e.g. clarifying a code definition or providing new usage instructions. 
+
+### 2.3 Patch version
+
+The patch version (X.Y.Z) is incremented for small changes that are backward compatible and do not affect the meaning or structure of existing content in individual terminology artefacts. 
+
+Examples include: 
+
+* Corrections to display names or definitions that do not affect semantic meaning. 
+* Making small technical or editorial updates or fixing bugs that do not affect system behaviour or require changes by users. 
+
+## 3 Versioning of MedCom Terminology IG
+
+MedCom applies a versioning model to manage updates to MedCom FHIR Terminology (https://medcomfhir.dk/ig/terminology/), using the format Major.Minor.Patch. 
+
+Changes to individual terminology artefacts do not automatically result in the same level of version change in the Terminology IG. The IG version is determined based on the overall impact of the update. 
+
+For instance, a minor change to a ValueSet may be reflected as a patch version in the MedCom Terminology IG. 
+
+Changes are documented in the Directory of published versions (https://medcomfhir.dk/ig/terminology/history.html) of the Terminology IG. 
+
+Examples: 
+
+* A new version of MedCom Terminology has been released as a major version which includes changes to artefacts (e.g. ValueSets and CodeSystems) not used in MedCom standard A. Standard A’s version is not affected at any level. 
+* A new version of MedCom Terminology has been released. ValueSet A’s version is changed at the minor level and the MedCom Terminology is changed at the patch level. Standard A, which incorporates ValueSet A, is updated on the major level. 
+* A new version of MedCom Terminology has been released, and it includes changes to multiple artefacts (e.g. ValueSets and CodeSystems) used in MedCom standard A. The IG of MedCom standard A will be updated to match the highest version change level (major > minor > patch) among the individual terminology artefacts it incorporates and not the version of the MedCom Terminology IG itself. 
+
+### 3.1 Major version
+
+The major version (X.0.0) is incremented when changes are introduced that may break backward compatibility or significantly alter the structure or meaning of one or more artefacts (e.g. Codesystems and ValueSets) in the MedCom Terminology IG. 
+
+Examples include: 
+
+* Major terminology structural changes to existing artefacts, such as CodeSystems or ValueSets. 
+
+### 3.2 Minor version
+
+The minor version (X.Y.0) is incremented when individual terminology artefacts (e.g. CodeSystems, ValueSets) are added, changed, or deprecated in a way that may impact core functionality in consuming systems, without changing the overall structure or methodology of the MedCom Terminology IG. Larger changes to existing artefacts, as well as the addition of entirely new artefacts, are managed through minor version updates as well. These changes are considered backward compatible at the Terminology IG framework level, but may require attention from implementers using affected artefacts. 
+
+Examples include: 
+
+* Addition of entirely new CodeSystems or ValueSets. 
+* Addition of a new group of codes (e.g. a new domain or category within an existing CodeSystem). 
+* Adding, deprecating or changing a code in a way that impacts functionality in systems using the terminology. 
+
+Changes that do not affect terminology functionality but still require updated documentation or user guidance. 
+
+### 3.3 Patch version
+
+The patch version (X.Y.Z) is incremented for small changes that are backward compatible and do not affect the meaning or structure of existing content in existing artefacts (e.g. Codesystems and ValueSets) in the MedCom Terminology IG. 
+
+Examples include: 
+
+* Addition of new individual codes to an existing artefact that do not affect system functionality. 
+* Corrections to display names or definitions that do not affect semantic meaning. 
+* Small technical or editorial updates (like contact info or version notes) that do not affect system behavior or require changes by users. 
+
+## 4 Governance for Terminology artefact dates
+
+The individual MedCom Terminology artefacts (such as CodeSystems) contain two types of dates that support version control and usage guidance. One applies to the entire artefact, while the other applies to individual codes or values within it. Dates in CodeSystems and ConceptMaps apply only to the artefact as a whole. CodeSystems contain both types of dates. The following outlines how these dates are used and interpreted. 
+
+**Date for the entire artifact:** 
+
+This date applies to the whole artifact and indicates the date of the most recent change. 
+
+**Date for each individual code in the CodeSystem:** 
+
+This date indicates the most recent status change date for the individual value/code. 
+
+There are four different statuses: 
+
+* Experimental: The code is recommended for trial use only. 
+* Active: The code is actively in use and recommended. 
+* Deprecated: Use is discouraged. It is expected to be retired in a future release. 
+* Retired: The code must no longer be used. 
+
+If a code or artifact does not have an associated date, it is because dates were not implemented in the terminology at the time of creation; they will be added the next time the element is updated.

--- a/docs/assets/documents/GovernanceTerminology.md
+++ b/docs/assets/documents/GovernanceTerminology.md
@@ -4,15 +4,20 @@
 
 **Table of contents**
 * [1 Introduction to Governance for MedCom FHIR Terminology](#1-introduction-to-governance-for-medcom-fhir-terminology)
-* [2 Versioning of individual artefacts in the MedCom Terminology IG](#2-versioning-of-individual-artefacts-in-the-medcom-terminology-ig)
-  + [2.1 Major version](#21-major-version)
-  + [2.2 Minor version](#22-minor-version)
-  + [2.3 Patch version](#23-patch-version)
-* [3 Versioning of MedCom Terminology IG](#3-versioning-of-medcom-terminology-ig)
-  + [3.1 Major version](#31-major-version)
-  + [3.2 Minor version](#32-minor-version)
-  + [3.3 Patch version](#33-patch-version)
-* [4 Governance for Terminology artefact dates](#4-governance-for-terminology-artefact-dates)
++ [1.1 MedCom FHIR CodeSystems](#11-medcom-fhir-codesystems)
++ [1.2 MedCom FHIR ValueSets](#12-medcom-fhir-valuesets)
++ [1.3 MedCom FHIR ConceptMaps](#13-medcom-fhir-conceptmaps)
+* [2 MedCom FHIR Terminology Versioning](#2-medcom-fhir-terminology-versioning)
+  + [2.1 Versioning of individual artefacts in the MedCom Terminology IG](#21-versioning-of-individual-artefacts-in-the-medcom-terminology-ig)
+    - [2.1.1 Major version](#211-major-version)
+    - [2.1.2 Minor version](#212-minor-version)
+    - [2.1.3 Patch version](#213-patch-version)
+  + [2.2 Versioning of individual artefacts in the MedCom Terminology IG](#22-versioning-of-individual-artefacts-in-the-medcom-terminology-ig)
+    - [2.2.1 Major version](#221-major-version)
+    - [2.2.2 Minor version](#222-minor-version)
+    - [2.2.3 Patch version](#223-patch-version)
+* [3 Governance for Terminology artefact dates](#3-governance-for-terminology-artefact-dates)
+* [4 Links for MedCom FHIR Terminology](#4-links-for-medcom-fhir-terminology)
 
 <br>
 
@@ -20,11 +25,33 @@
 
 Governance for MedCom FHIR Terminology covers version management and dates Codesystems, Valuesets and ConceptMaps, which are published through the MedCom FHIR Terminology IG.
 
-<br>
+The term Terminology is in this governance a term covering all kinds of terminology, classifications, enumerations and qualifiers.
+
+All elements of a MedCom FHIR Message **SHALL** be compliant with the terminologies that are pointed out by these elements. No updates will be made without consulting relevant working groups beforehand.
+
+### 1.1 MedCom FHIR CodeSystems
+
+No code in a CodeSystem will be deleted. Incompatible versions of a CodeSystem will have a unique name. Codes in CodeSystems may be deprecated with a deprecation date and new codes may be added to the CodeSystem. In both cases will the version and date be updated.
+
+### 1.2 MedCom FHIR ValueSets
+
+Some ValueSets are intensional defined, meaning that all codes from a CodeSystem is included. Whenever the CodeSystem is updated, so is the ValueSet. For intensional defined ValueSets, there will always only be one active ValueSet.
+
+Other ValueSets are extensional defined, meaning that codes from CodeSystems are explicitly listed in each ValueSet. ValueSets will therefore not automatically be expanded when a CodeSystem is - it requires a change in the ValueSet.
+
+In exceptional cases, a ValueSet may be marked as fixed, meaning it must not be changed or versioned.
+
+### 1.3 MedCom FHIR ConceptMaps
+
+ConceptMaps may be more or less static. ConceptMaps used for sending purposes will rarely change, and ConceptMaps used to describe the content of a message/document may change more frequently.
+
+A ConceptMap is valid until the date of a newer version of this ConceptMap is reached - then only the newest version is valid. If a code in a CodeSystem is deprecated, a new version of the ConceptMaps is created.
+
+## 2 MedCom FHIR Terminology Versioning
 
 MedCom defines a separation between versioning of the overall MedCom Terminology Implementation Guide (IG) and the individual terminology artefacts, such as CodeSystems, ValueSets, and ConceptMaps. While the Terminology IG is versioned as a whole, each terminology artefact is versioned independently to ensure precise tracking of changes and stable references across MedCom standards.
 
-## 2 Versioning of individual artefacts in the MedCom Terminology IG
+### 2.1 Versioning of individual artefacts in the MedCom Terminology IG
 
 MedCom applies a versioning model to manage updates to individual MedCom FHIR Terminology artefacts (CodeSystems, ValueSets, ConceptMaps), using the format Major.Minor.Patch. 
 
@@ -37,7 +64,7 @@ Examples:
 * A minor change in a ValueSet will result in a minor version change in the standards that incorporate it. 
 * MedCom releases a new major version of multiple terminology artefacts not used in MedCom standard A. Standard A’s version is then not affected on any level.
 
-### 2.1 Major version
+#### 2.1.1 Major version
 
 The major version (X.0.0) is incremented when changes are introduced that may break backward compatibility or significantly alter the structure or meaning of the individual terminology artefact. 
 
@@ -48,7 +75,7 @@ Examples include:
 * Embedding a group from one terminology artefact into another terminology artefact. 
 * Adding, deprecating or changing a code in a way that impacts functionality in systems using the terminology.
 
-### 2.2 Minor version
+#### 2.1.2 Minor version
 
 The minor version (X.Y.0) is incremented when new content is added in a way that is fully backward compatible and does not alter the structure or semantics of existing terminology artefacts. 
 
@@ -57,7 +84,7 @@ Examples include:
 * Addition of one or more new codes to existing terminology artefacts (e.g. a new category). 
 * Changes that do not affect functionality but still require updated documentation or user guidance – e.g. clarifying a code definition or providing new usage instructions. 
 
-### 2.3 Patch version
+#### 2.1.3 Patch version
 
 The patch version (X.Y.Z) is incremented for small changes that are backward compatible and do not affect the meaning or structure of existing content in individual terminology artefacts. 
 
@@ -66,7 +93,7 @@ Examples include:
 * Corrections to display names or definitions that do not affect semantic meaning. 
 * Making small technical or editorial updates or fixing bugs that do not affect system behaviour or require changes by users. 
 
-## 3 Versioning of MedCom Terminology IG
+### 2.2 Versioning of MedCom Terminology IG
 
 MedCom applies a versioning model to manage updates to MedCom FHIR Terminology (https://medcomfhir.dk/ig/terminology/), using the format Major.Minor.Patch. 
 
@@ -82,7 +109,7 @@ Examples:
 * A new version of MedCom Terminology has been released. ValueSet A’s version is changed at the minor level and the MedCom Terminology is changed at the patch level. Standard A, which incorporates ValueSet A, is updated on the major level. 
 * A new version of MedCom Terminology has been released, and it includes changes to multiple artefacts (e.g. ValueSets and CodeSystems) used in MedCom standard A. The IG of MedCom standard A will be updated to match the highest version change level (major > minor > patch) among the individual terminology artefacts it incorporates and not the version of the MedCom Terminology IG itself. 
 
-### 3.1 Major version
+#### 2.2.1 Major version
 
 The major version (X.0.0) is incremented when changes are introduced that may break backward compatibility or significantly alter the structure or meaning of one or more artefacts (e.g. Codesystems and ValueSets) in the MedCom Terminology IG. 
 
@@ -90,7 +117,7 @@ Examples include:
 
 * Major terminology structural changes to existing artefacts, such as CodeSystems or ValueSets. 
 
-### 3.2 Minor version
+#### 2.2.2 Minor version
 
 The minor version (X.Y.0) is incremented when individual terminology artefacts (e.g. CodeSystems, ValueSets) are added, changed, or deprecated in a way that may impact core functionality in consuming systems, without changing the overall structure or methodology of the MedCom Terminology IG. Larger changes to existing artefacts, as well as the addition of entirely new artefacts, are managed through minor version updates as well. These changes are considered backward compatible at the Terminology IG framework level, but may require attention from implementers using affected artefacts. 
 
@@ -102,7 +129,7 @@ Examples include:
 
 Changes that do not affect terminology functionality but still require updated documentation or user guidance. 
 
-### 3.3 Patch version
+#### 2.2.3 Patch version
 
 The patch version (X.Y.Z) is incremented for small changes that are backward compatible and do not affect the meaning or structure of existing content in existing artefacts (e.g. Codesystems and ValueSets) in the MedCom Terminology IG. 
 
@@ -112,7 +139,7 @@ Examples include:
 * Corrections to display names or definitions that do not affect semantic meaning. 
 * Small technical or editorial updates (like contact info or version notes) that do not affect system behavior or require changes by users. 
 
-## 4 Governance for Terminology artefact dates
+## 3 Governance for Terminology artefact dates
 
 The individual MedCom Terminology artefacts (such as CodeSystems) contain two types of dates that support version control and usage guidance. One applies to the entire artefact, while the other applies to individual codes or values within it. Dates in CodeSystems and ConceptMaps apply only to the artefact as a whole. CodeSystems contain both types of dates. The following outlines how these dates are used and interpreted. 
 
@@ -132,3 +159,11 @@ There are four different statuses:
 * Retired: The code must no longer be used. 
 
 If a code or artifact does not have an associated date, it is because dates were not implemented in the terminology at the time of creation; they will be added the next time the element is updated.
+
+## 4 Links for MedCom FHIR Terminology
+
+| Links for Terminology|
+|:---|
+|<a href="https://medcomdk.github.io/dk-medcom-terminology/">Detailed specification for MedCom FHIR Terminology server</a>
+|<a href="https://medcomfhir.dk/ig/terminology/" target="_blank">Detailed specification for MedCom FHIR Terminology in MedCom FHIR Terminology IG</a>
+|<a href="http://hl7.org/fhir/R4/terminology-service.html" target="_blank">Detailed specification for Terminology in FHIR R4</a>

--- a/docs/assets/documents/GovernanceTerminology.md
+++ b/docs/assets/documents/GovernanceTerminology.md
@@ -29,6 +29,8 @@ The term Terminology is in this governance a term covering all kinds of terminol
 
 All elements of a MedCom FHIR Message **SHALL** be compliant with the terminologies that are pointed out by these elements. No updates will be made without consulting relevant working groups beforehand.
 
+MedCom applies semantic versioning. Read MedCom's description of semantic versioning [here](https://medcomdk.github.io/MedComLandingPage/#41-versioning-of-fhir-standard).
+
 ### 1.1 MedCom FHIR CodeSystems
 
 No code in a CodeSystem will be deleted. Incompatible versions of a CodeSystem will have a unique name. Codes in CodeSystems may be deprecated with a deprecation date and new codes may be added to the CodeSystem. In both cases will the version and date be updated.
@@ -95,13 +97,13 @@ Examples include:
 
 ### 2.2 Versioning of MedCom Terminology IG
 
-MedCom applies a versioning model to manage updates to MedCom FHIR Terminology (https://medcomfhir.dk/ig/terminology/), using the format Major.Minor.Patch. 
+MedCom applies a versioning model to manage updates to [MedCom FHIR Terminology](https://medcomfhir.dk/ig/terminology/), using the format Major.Minor.Patch. 
 
 Changes to individual terminology artefacts do not automatically result in the same level of version change in the Terminology IG. The IG version is determined based on the overall impact of the update. 
 
 For instance, a minor change to a ValueSet may be reflected as a patch version in the MedCom Terminology IG. 
 
-Changes are documented in the Directory of published versions (https://medcomfhir.dk/ig/terminology/history.html) of the Terminology IG. 
+Changes are documented in the [Directory of published versions](https://medcomfhir.dk/ig/terminology/history.html) of the Terminology IG. 
 
 Examples: 
 

--- a/docs/assets/documents/GovernanceTerminology.md
+++ b/docs/assets/documents/GovernanceTerminology.md
@@ -57,7 +57,7 @@ MedCom defines a separation between versioning of the overall MedCom Terminology
 
 MedCom applies a versioning model to manage updates to individual MedCom FHIR Terminology artefacts (CodeSystems, ValueSets, ConceptMaps), using the format Major.Minor.Patch. 
 
-Each component of the version number signals the type and impact of a change. Any MedCom standards affected by changes of individual terminology artefacts in the MedCom Terminology IG will reflect the same version change level as the artefact it incorporates that has the highest level of change (major > minor > patch). MedCom will communicate changes at the major and minor version levels to affected vendors. Vendors must be able to handle patch level changes without being notified by MedCom.
+Each component of the version number signals the type and impact of a change. Any MedCom standards affected by changes of individual terminology artefacts in the MedCom Terminology IG will reflect the same version change level as the artefact it incorporates that has the highest level of change (major > minor > patch). MedCom will communicate changes at the major and minor version levels to affected vendors. Vendors must be able to handle patch level changes without being notified by MedCom. Venders can use GitHub subscriptions to get notifications.
 
 <br>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -212,8 +212,8 @@ If a document or an IG has an extra number eg. 2.1.4-a.1 it is a prerelease and 
 <p>&nbsp;</p>
 
 ### 4.2 Governance of Medcom FHIR Terminology
-Governance for MedCom FHIR Terminology covers version management and dates Codesystems, Valuesets and ConceptMaps, which are published through the MedCom FHIR Terminology IG.
-[Click here to get more information about the governance for MedCom FHIR Terminology](assets/documents/TouchStoneGettingStarted.md)
+Governance of MedCom FHIR Terminology covers change management and versioning of the Terminology IG and corresponding affected standards. It specificlally adresses Codesystems, Valuesets and ConceptMaps, which are published through the MedCom FHIR Terminology IG.
+[Click here to get more information about the governance for MedCom FHIR Terminology](assets/documents/GovernanceTerminology.md)
 <p>&nbsp;</p>
 
 ### 4.3 Change requests and improvements

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Lastly, the terminology codes (Danish: terminologi), including all CodeSystems, 
 
 Due to the above mentioned, the <a href="#Tab1"> Table 1</a> is divided into three parts: 
 1. MedCom's FHIR standards describes the MedCom FHIR standards and their business requirements.  
-2. Terminology describes the terminology XDS-metadata used in the MedCom FHIR standards.
+2. Terminology describes the terminology used in the MedCom FHIR standards.
 3. Generic profiles describes the profiles used across MedCom FHIR standards. 
 
 <br>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,8 @@
 * [1 MedComs FHIR standards](#1-medcoms-fhir-standards)
 * [2 Implementing a MedCom FHIR standard](#2-implementing-a-medcom-fhir-standard)
   * [2.1 Standard documentation](#21-standard-documentation)
-  * [2.2 Governance for MedCom HL7 FHIR®© Messaging](#22-governance-for-medcom-hl7-fhir-messaging) 
+  * [2.2 General goverance for MedCom FHIR standards](#22-general-goverance-for-medcom-fhir-standards)
+  * [2.3 Governance for MedCom HL7 FHIR®© Messaging](#23-governance-for-medcom-hl7-fhir-messaging) 
 * [3 Test and certification](#3-test-and-certification)
   * [3.1 Test of FHIR messages](#31-test-of-fhir-messages)
 * [4 Change management and versioning](#4-change-management-and-versioning)
@@ -156,11 +157,11 @@ The links to the webpage presentations of the standards can be found in the <a h
 When implementing a MedCom FHIR standard, it is fundamental to understand in which context the standard should be used to ensure that the implementation fulfils the business requirements. Therefore, it is important to understand the standard documentation for the given standard. 
 Furthermore, it is essential to understand the messaging framework and the possibilities of the VANS Network, as the FHIR standards define the process for how information is packaged and sent from one part to another thtough the VANS Network.
 The messaging framework and the VANS Network are described as governance, previously known as the “Syntax and Communication Rules". <br>
-<a href="https://medcomdk.github.io/MedCom-FHIR-Communication/#network-layer" target="_blank"> Click here to get more information about governance.</a>  
-<br>
+[Click here to get more information about governance.](assets/documents/TouchStoneGettingStarted.md).
+<p>&nbsp;</p>
 
 ### 2.1 Standard documentation
-The purpose of the standard documentation is to describe the context in which a standard should be used and which requirements the standard should fulfil. Standard documentation is only provided for Medcom's FHIR standards and thus not for the generic Core or Messaging Profiles. The content of the standard documentation can vary between the standards. 
+The purpose of the standard documentation is to describe the context in which a standard should be used and which requirements the standard should fulfil. Standard documentation is only provided for Medcom's FHIR standards and thus not for the generic Core or, Document or Messaging Profiles. The content of the standard documentation can vary between the standards.
 
 <!-- An implementation guide, use cases, clinical guidelines for application and testprotocols will be available for all standards -->
 
@@ -173,9 +174,14 @@ The standard documentation can consist of:
 * **Mapping document**: the mapping from the previous OIOXML standard to FHIR.
 <p>&nbsp;</p>
 
+### 2.2 General goverance for MedCom FHIR standards
+The general governance is important to understand before implementing a MedCom FHIR standard, as it describes general governance for both MedCom FHIR document and messaging standards. Governance for the two individual standard types can be found below.
+<a href="https://medcomdk.github.io/MedCom-FHIR-Communication/#network-layer" target="_blank"> Click here to get more information about the general governance for MedCom FHIR standards.</a>  
+<p>&nbsp;</p>
+
 ### 2.2 Governance for MedCom HL7 FHIR Messaging
-The governance is important to understand before implementing a MedCom FHIR standard, as it describes the Danish profiling of the FHIR messaging framework and the network layer, which is the VANS network at present. Since the existing VANS network is used to deliver messages, messages must be sent in a VANSenvelope unless otherwise specified. <br>
-<a href="https://medcomdk.github.io/MedCom-FHIR-Communication/#network-layer" target="_blank"> Click here to get more information about governance.</a>  
+The messaging governance is important to understand before implementing a MedCom FHIR messaging standard, as it describes the Danish profiling of the FHIR messaging framework and the network layer, which is the VANS network at present. Since the existing VANS network is used to deliver messages, messages must be sent in a VANSenvelope unless otherwise specified. <br>
+<a href="https://medcomdk.github.io/MedCom-FHIR-Communication/#network-layer" target="_blank"> Click here to get more information about messaging governance.</a>  
 <p>&nbsp;</p>
 
 ## 3 Test and certification

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,13 +154,13 @@ The links to the webpage presentations of the standards can be found in the <a h
 
 
 ## 2 Implementing a MedCom FHIR standard
-When implementing a MedCom FHIR standard, it is fundamental to understand in which context the standard should be used to ensure that the implementation fulfils the business requirements. Therefore, it is important to understand the standard documentation for the given standard. 
+When implementing a MedCom FHIR standard, it is fundamental to understand in which context the standard should be used to ensure that the implementation fulfills the business requirements. Therefore, it is important to understand the standard documentation for the given standard. 
 Furthermore, it is essential to understand the governance, as it defines the process for how information is packaged and sent.
 <br>
 <p>&nbsp;</p>
 
 ### 2.1 Standard documentation
-The purpose of the standard documentation is to describe the context in which a standard should be used and which requirements the standard should fulfil. Standard documentation is only provided for Medcom's FHIR standards and thus not for the generic Core or, Document or Messaging Profiles. The content of the standard documentation can vary between the standards.
+The purpose of the standard documentation is to describe the context in which a standard should be used and which requirements the standard should fulfill. Standard documentation is only provided for Medcom's FHIR standards and thus not for the generic Core or, Document or Messaging Profiles. The content of the standard documentation can vary between the standards.
 
 <!-- An implementation guide, use cases, clinical guidelines for application and testprotocols will be available for all standards -->
 
@@ -169,7 +169,7 @@ The standard documentation can consist of:
 * **Implementation Guide**: the technical specifications of the standard.
 * **Clinical guidelines for application**: the clinical consideration behind the modernisation.
 * **Use cases**: the intended use of the standard.
-* **Testprotocol**: used during test and certification to document that the vendor implementation fulfils the standard. 
+* **Testprotocol**: used during test and certification to document that the vendor implementation fulfills the standard. 
 * **Mapping document**: the mapping from the previous OIOXML standard to FHIR.
 <p>&nbsp;</p>
 
@@ -184,7 +184,7 @@ The messaging governance is important to understand before implementing a MedCom
 <p>&nbsp;</p>
 
 ## 3 Test and certification
-Before using the implemented standard in a production environment to exchange patient data, it must be tested and certified by MedCom to ensure it fulfils the standard and business requirements. In addition to the usual <a href="https://medcom.dk/standarder/test-og-certificering/" target="_blank">MedCom test setup</a> with a self test and live test, <a href="https://touchstone.aegis.net/touchstone/" target="_blank">TouchStone</a> is used as a tool to validate FHIR messages sent in different use cases.
+Before using the implemented standard in a production environment to exchange patient data, it must be tested and certified by MedCom to ensure it fulfills the standard and business requirements. In addition to the usual <a href="https://medcom.dk/standarder/test-og-certificering/" target="_blank">MedCom test setup</a> with a self test and live test, <a href="https://touchstone.aegis.net/touchstone/" target="_blank">TouchStone</a> is used as a tool to validate FHIR messages sent in different use cases.
 
 TouchStone is an infrastructure that allows for automated tests against implementations of HL7 FHIR. For each FHIR standard MedCom will develope test scripts, that will be available in TouchStone. These test scripts can be used both during implementation/development and as a part of the test and certification. <br>
 [Click here to get started with TouchStone](assets/documents/TouchStoneGettingStarted.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,8 +194,8 @@ TouchStone is an infrastructure that allows for automated tests against implemen
 <p>&nbsp;</p>
 
 ### 3.1 Test of FHIR Messages and Documents
-Since MedCom's FHIR messages are sent over the VANS network, vendors implementing messaging standards must to be able to include the message in a VANSenvelope before sending the message, typically in the Danish national Document Sharing infrastructure (DDS).<br>
-Vendors implementing MedCom's FHIR document standards must be able to share documents in the relevant infrastructure.<br>
+Since MedCom's FHIR messages are sent over the VANS network, vendors implementing messaging standards must to be able to include the message in a VANSenvelope before sending the message.<br>
+Vendors implementing MedCom's FHIR document standards must be able to share documents in the relevant infrastructure, typically in the Danish national Document Sharing infrastructure (DDS).<br>
 Vendors should expect to demonstrate this as a part of test and certification.
 
 ## 4 Change management and versioning  

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ The links to the webpage presentations of the standards can be found in the <a h
 </thead>
 <tbody>
   <tr>
-    <td class="tg-1ady" colspan="4"><span style="font-style:italic">MedCom's FHIR standards</span></td>
+    <td class="tg-1ady" colspan="4"><span style="font-style:italic">MedCom's Messaging standards</span></td>
   </tr>
   <tr>
     <td class="tg-on52"><a href="https://medcomdk.github.io/dk-medcom-hospitalnotification/" rel="noopener noreferrer"><span style="text-decoration:none">HospitalNotification</span></a></td>
@@ -102,6 +102,9 @@ The links to the webpage presentations of the standards can be found in the <a h
     <td class="tg-on52"><span style="background-color:#FFF">Kommunale Prøvesvar</span></td>
     <td class="tg-on52"><span style="background-color:#FFF">This standard is developed to be part of a production trial of the communication between the general practitioner and municipal acute care team. Used to exchange results and observations performed and produced by the municipal acute care team. </span></td>
     <td class="tg-on52"> Version 1.0</td>
+  </tr>
+    <tr>
+    <td class="tg-1ady" colspan="4"><span style="font-style:italic">MedCom's Document standards</span></td>
   </tr>
   </tr>
     <tr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,38 +14,38 @@
 * [6 New to FHIR?](#New-to-fhir)
 * [7 Frequently asked questions](#7-frequently-asked-questions)
 
-> Note: Clinical guidelines and use case documents are available in both Danish and English. All the remaining documentation will be in English.
+> Note: Clinical guidelines are available in both Danish and English. All the remaining documentation will be in English.
 <p>&nbsp;</p>
 
 MedCom's modernisation project involves both rethinking business requirements and technical improvement. The modernisation is done in collaboration with MedCom's central partners. 
 
 On our website <a href="https://www.medcom.dk/standarder/modernisering-af-medcom-standarder/" target="_blank">medcom.dk </a>, the political and strategical aspects of the modernisation are described. These aspects involve the initial wave of modernisation including HospitalNotification (Danish: Advis om sygehusophold), CareCommunication (Danish: Korrespondancemeddelelse), and Acknowledgement (Danish: Kvittering) standards. Furthermore, you can find descriptions of the gradual phase-out of the existing standard formats (EDIFACT and OIOXML), the implementation plan for the initial wave and descriptions of the upcoming waves of modernisation.
 
-The purpose of this site is to guide you to find both the business and technical implementation of the requirements for each standard. 
+The purpose of this site is to guide you to find both the business and technical implementation of the requirements for each standard.
 <p>&nbsp;</p>
 
 ## 1 MedCom's FHIR standards
 The business requirements describe the context in which a standard should be used, and they are presented on a webpage for each standard.
 For a MedCom FHIR standard, the technical implementation is presented in an Implementation Guide (IG). An IG includes several rules, extensions, profiles and more. Each profile describes a delimited area within healthcare e.g., a patient, an organisation, or an encounter.
-Some of the profiles are often used across standards. An example is the Patient profile which includes the most central information about a patient or citizen, such as the civil registration number (Danish: CPR-nummer) or name. These types of profiles are called core profiles (Danish: kerneprofiler) and are gathered in the Core IG. Additionally, some profiles are often used when defining a message. These profiles are called messaging profiles (Danish: meddelelsesprofiler) and are gathered in the Messaging IG. 
+Some of the profiles are often used across standards. An example is the Patient profile which includes the most central information about a patient or citizen, such as the civil registration number (Danish: CPR-nummer) or name. These types of profiles are called core profiles (Danish: kerneprofiler) and are gathered in the Core IG. Additionally, some profiles are often used when defining a message. These profiles are called messaging profiles (Danish: meddelelsesprofiler) and are gathered in the Messaging IG. The same applies to MedCom FHIR documents.
 Some profiles are specific for a standard, which is why they are gathered in the respective IG. 
 Lastly, the terminology codes (Danish: terminologi), including all CodeSystems, ValueSet, and ConceptMaps are gathered in the Terminology IG.
-Currently, there are three FHIR standards: HospitalNotification, CareCommunication, and Acknowledgement, which are all composed of profiles from the Core and Messaging IG as well as the IG for the specific standard, and codes from the Terminology IG. 
 
 Due to the above mentioned, the <a href="#Tab1"> Table 1</a> is divided into three parts: 
 1. MedCom's FHIR standards describes the MedCom FHIR standards and their business requirements.  
-2. Terminology explanation describes the terminology used in the MedCom FHIR standards.
+2. Terminology describes the terminology XDS-metadata used in the MedCom FHIR standards.
 3. Generic profiles describes the profiles used across MedCom FHIR standards. 
 
 <br>
-Over time, the modernised FHIR standards will replace the existing MedCom standards. HospitalNotification replaces 
+Over time, the modernised FHIR standards will replace the existing MedCom standards. For example, HospitalNotification replaces 
 <a href="https://svn.medcom.dk/svn/releases/Standarder/Det%20gode%20kommuneadvis/EDI/Dokumentation/" target="_blank">DIS17</a>/
 <a href="https://svn.medcom.dk/svn/releases/Standarder/Det%20gode%20kommuneadvis/XDIS17/Dokumentation/" target="_blank">XDIS17</a> and
 <a href="https://svn.medcom.dk/svn/releases/Standarder/Det%20gode%20kommuneadvis/EDI/Dokumentation/" target="_blank">DIS20</a>/
 <a href="https://svn.medcom.dk/svn/releases/Standarder/Det%20gode%20kommuneadvis/XDIS20/Dokumentation/" target="_blank">XDIS20</a>. CareCommunication replaces 
 <a href="https://svn.medcom.dk/svn/releases/Standarder/Den%20gode%20korrespondance/EDI/Dokumentation/" target="_blank">DIS91</a>/ <a href="https://svn.medcom.dk/svn/releases/Standarder/Den%20gode%20korrespondance/XML/Dokumentation/" target="_blank">XDIS91 </a> and Acknowledgement replaces <a href="https://svn.medcom.dk/svn/releases/Standarder/Den%20gode%20CONTRL/EDI/Dokumentation/" target="_blank">CTL01-03</a>/<a href="https://svn.medcom.dk/svn/releases/Standarder/Den%20gode%20CONTRL/XML/Dokumentation/" target="_blank">XCTL01-03 </a>.
 
-The links to the webpage presentations of the standards can be found in the <a href="#Tab1"> Table 1</a>. On the webpages, you can find the links to the IG and other relevant information.
+<br>
+The links to the webpage presentations of the standards can be found in the <a href="#Tab1"> Table 1</a>. On the webpages, you can find the links to the IG and other relevant information that is essential for the individual standard.
 
 <style type="text/css">
 .tg  {border-collapse:collapse;border-spacing:0; width:50%;}
@@ -108,7 +108,7 @@ The links to the webpage presentations of the standards can be found in the <a h
     <td class="tg-on52"><span style="background-color:#FFF"> <a href="https://medcomdk.github.io/dk-medcom-conditionlist/" rel="noopener noreferrer"><span style="text-decoration:none">ConditionList</span></a></span></td>
     <td class="tg-on52"><span style="background-color:#FFF">Deling af diagnoser</span></td>
     <td class="tg-on52"><span style="background-color:#FFF">This document based standard is developed to support sharing of a citizens diagnoses selected by the citizens general practitioner to the citizen and healthcare providers</span></td>
-    <td class="tg-on52">-</td>
+    <td class="tg-on52"> Version 1.0</td>
   </tr>
   <tr>
     <td class="tg-1ady" colspan="4"><span style="font-style:italic">Terminology</span></td>
@@ -155,9 +155,8 @@ The links to the webpage presentations of the standards can be found in the <a h
 
 ## 2 Implementing a MedCom FHIR standard
 When implementing a MedCom FHIR standard, it is fundamental to understand in which context the standard should be used to ensure that the implementation fulfils the business requirements. Therefore, it is important to understand the standard documentation for the given standard. 
-Furthermore, it is essential to understand the messaging framework and the possibilities of the VANS Network, as the FHIR standards define the process for how information is packaged and sent from one part to another thtough the VANS Network.
-The messaging framework and the VANS Network are described as governance, previously known as the “Syntax and Communication Rules". <br>
-[Click here to get more information about governance.](assets/documents/TouchStoneGettingStarted.md).
+Furthermore, it is essential to understand the governance, as it defines the process for how information is packaged and sent.
+<br>
 <p>&nbsp;</p>
 
 ### 2.1 Standard documentation
@@ -168,15 +167,15 @@ The purpose of the standard documentation is to describe the context in which a 
 <!-- .Furthermore, some additional documents might be available to support implementation, such as a mapping document.  -->
 The standard documentation can consist of: 
 * **Implementation Guide**: the technical specifications of the standard.
-* **Clinical guidelines for appliccation**: the clinical consideration behind the modernisation.
+* **Clinical guidelines for application**: the clinical consideration behind the modernisation.
 * **Use cases**: the intended use of the standard.
 * **Testprotocol**: used during test and certification to document that the vendor implementation fulfils the standard. 
 * **Mapping document**: the mapping from the previous OIOXML standard to FHIR.
 <p>&nbsp;</p>
 
 ### 2.2 General goverance for MedCom FHIR standards
-The general governance is important to understand before implementing a MedCom FHIR standard, as it describes general governance for both MedCom FHIR document and messaging standards. Governance for the two individual standard types can be found below.
-<a href="https://medcomdk.github.io/MedCom-FHIR-Communication/#network-layer" target="_blank"> Click here to get more information about the general governance for MedCom FHIR standards.</a>  
+The general governance is important to understand before implementing a MedCom FHIR standard, as it describes the general governance for both MedCom FHIR document and messaging standards. Governance for the individual standard types can be found below.
+[Click here to get more information about the general governance for MedCom FHIR standards.](assets/documents/GeneralGovernanceFHIRStandards.md)
 <p>&nbsp;</p>
 
 ### 2.2 Governance for MedCom HL7 FHIR Messaging
@@ -187,16 +186,18 @@ The messaging governance is important to understand before implementing a MedCom
 ## 3 Test and certification
 Before using the implemented standard in a production environment to exchange patient data, it must be tested and certified by MedCom to ensure it fulfils the standard and business requirements. In addition to the usual <a href="https://medcom.dk/standarder/test-og-certificering/" target="_blank">MedCom test setup</a> with a self test and live test, <a href="https://touchstone.aegis.net/touchstone/" target="_blank">TouchStone</a> is used as a tool to validate FHIR messages sent in different use cases.
 
-TouchStone is an infrastructure that allows for automated tests against implementations of HL7 FHIR. For each FHIR standard MedCom will develope test scripts, that will be available on TouchStone. These test scripts can be used both during implementation and as a part of the test and certification. <br>
+TouchStone is an infrastructure that allows for automated tests against implementations of HL7 FHIR. For each FHIR standard MedCom will develope test scripts, that will be available in TouchStone. These test scripts can be used both during implementation/development and as a part of the test and certification. <br>
 [Click here to get started with TouchStone](assets/documents/TouchStoneGettingStarted.md)
 <p>&nbsp;</p>
 
-### 3.1 Test of FHIR Messages
-Since MedCom's FHIR messages are sent over the VANS network, vendors must to be abel to include the message in a VANSenvelope before sending the message. Vendors should expect to demonstrate this as a part of test and certification. 
+### 3.1 Test of FHIR Messages and Documents
+Since MedCom's FHIR messages are sent over the VANS network, vendors implementing messaging standards must to be abel to include the message in a VANSenvelope before sending the message.<br>
+Vendors implementing MedCom's FHIR document standards must be able to share documents in the relevant infrastructure.<br>
+Vendors should expect to demonstrate this as a part of test and certification.
 
 ## 4 Change management and versioning  
 
-### 4.1 Versioning of FHIR standard
+### 4.1 Versioning of Medcom FHIR standards
 MedComs FHIR standards follow the <a href="https://semver.org/" target="_blank">semantic versioning, version 2.0</a>, which is adjusted to the workflow in MedCom. Each document, such as the clinical guidelines, use cases or other documentation, will have a version and a release note, to keep track of the changes in the document. The IG will have one version that covers all the included artefacts. Versioning of the clinical guidelines, use cases, test material, and more will follow the major and minor version of the technical specifications in the IG, but may have a patch version that is different from the IG’s patch-version.
 
 Semantic versioning includes three numbers, which are separated by a dot, e.g. 2.1.4. The numbers are called <i>major.minor.patch</i>,which represent different degrees of changes: 
@@ -210,7 +211,12 @@ If a document or an IG has an extra number eg. 2.1.4-a.1 it is a prerelease and 
 <a href="https://svn.medcom.dk/svn/qms/Offentlig/SOPer/" target="_blank">Click here to read SOP-4.1.</a> 
 <p>&nbsp;</p>
 
-### 4.2 Change requests and improvements
+### 4.2 Governance of Medcom FHIR Terminology
+Governance for MedCom FHIR Terminology covers version management and dates Codesystems, Valuesets and ConceptMaps, which are published through the MedCom FHIR Terminology IG.
+[Click here to get more information about the governance for MedCom FHIR Terminology](assets/documents/TouchStoneGettingStarted.md)
+<p>&nbsp;</p>
+
+### 4.3 Change requests and improvements
 Stakeholders and vendors are alway welcome to submit requests for changes or improvements to the IG or other documentation. 
 * If the request concerns the IG, it is possible to: 
   1. submit an issue to the relevant <a href="https://github.com/medcomdk" target="_blank">MedCom GitHub repository</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,7 +194,7 @@ TouchStone is an infrastructure that allows for automated tests against implemen
 <p>&nbsp;</p>
 
 ### 3.1 Test of FHIR Messages and Documents
-Since MedCom's FHIR messages are sent over the VANS network, vendors implementing messaging standards must to be able to include the message in a VANSenvelope before sending the message.<br>
+Since MedCom's FHIR messages are sent over the VANS network, vendors implementing messaging standards must to be able to include the message in a VANSenvelope before sending the message, typically in the Danish national Document Sharing infrastructure (DDS).<br>
 Vendors implementing MedCom's FHIR document standards must be able to share documents in the relevant infrastructure.<br>
 Vendors should expect to demonstrate this as a part of test and certification.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,7 +163,7 @@ Furthermore, it is essential to understand the governance, as it defines the pro
 <p>&nbsp;</p>
 
 ### 2.1 Standard documentation
-The purpose of the standard documentation is to describe the context in which a standard should be used and which requirements the standard should fulfill. Standard documentation is only provided for Medcom's FHIR standards and thus not for the generic Core or, Document or Messaging Profiles. The content of the standard documentation can vary between the standards.
+The purpose of the standard documentation is to describe the context in which a standard should be used and which requirements the standard should fulfill. Standard documentation is only provided for Medcom's FHIR standards and thus not for the generic Core or, Document or Messaging Profiles. The content of the standard documentation can vary between the standards. It may be useful to note that the terms *standards* and *profiles* are often used interchangeably, at least in the context of a MedCom FHIR Message and a MedCom FHIR Document.
 
 <!-- An implementation guide, use cases, clinical guidelines for application and testprotocols will be available for all standards -->
 
@@ -194,7 +194,7 @@ TouchStone is an infrastructure that allows for automated tests against implemen
 <p>&nbsp;</p>
 
 ### 3.1 Test of FHIR Messages and Documents
-Since MedCom's FHIR messages are sent over the VANS network, vendors implementing messaging standards must to be abel to include the message in a VANSenvelope before sending the message.<br>
+Since MedCom's FHIR messages are sent over the VANS network, vendors implementing messaging standards must to be able to include the message in a VANSenvelope before sending the message.<br>
 Vendors implementing MedCom's FHIR document standards must be able to share documents in the relevant infrastructure.<br>
 Vendors should expect to demonstrate this as a part of test and certification.
 


### PR DESCRIPTION
Hi @ovi-medcom and @olw-medcom 

Will you review these 2 things? :
1) I have seperated parts of our governance. Some of the governance was placed in messaging governance, but also applies to document sharing and is therefore move to general governance. General governance and messaging governance are placed in seperate repos, which is why you got 2 PRs.

2) I also specifically took the old Terminology governance description from the messaging repo and moved it to the general repo. I added my suggestion for versioning to the old terminology description so that you can review it as a whole. Feel free to comment, ask questions and assess whether the new governance for terminology is correct.